### PR TITLE
SemaphoreLeave are missing when health data are null/false

### DIFF
--- a/Robonect/module.php
+++ b/Robonect/module.php
@@ -117,6 +117,8 @@ class RobonectWifiModul extends IPSModule
         // Get Health Data
         $data = $this->executeHTTPCommand( 'health' );
         if ($data == false) {
+            IPS_SemaphoreLeave( $semaphore );
+            $this->log('Update - Semaphore leaved' );
             return false;
         } elseif ( isset( $data['successful'] ) ) {#
             $this->updateIdent("mowerVoltageInternal", $data['health']['voltages']['int3v3']/1000 );


### PR DESCRIPTION
In the Update method when the Get Health Data are null/false the only return false -> the Semaphore are not leaving.